### PR TITLE
Proposal to include r-geometa.md (geometa tool)

### DIFF
--- a/tools/r-geometa.md
+++ b/tools/r-geometa.md
@@ -1,0 +1,22 @@
+---
+title: geometa
+slug: r-geometa
+website: http://github.com/eblondel/geometa
+description: |
+  <p><b>geometa</b> is an R package that offers facilities to handle reading and writing 
+  of geographic metadata defined with OGC/ISO 19115, 11119 and 19110 geographic information 
+  metadata standards, and encoded using the ISO 19139 (XML) standard. It includes also a 
+  facility to check the validity of ISO 19139 XML encoded metadata. The package can be used 
+  in integrated (meta)data management flows to generate business metadata compliant with ISO/OGC 
+  standards. Metadata generated with 'geometa' can then be published to standard web metadata 
+  catalogues by means of related R packages such as <a href="http://github.com/eblondel/ows4R/wiki" target="_blank">ows4R</a> 
+  (R interface to OGC Web-Services) or <a href="http://github.com/eblondel/geonapi/wiki" target="_blank">geonapi</a> (R Interface to GeoNetwork API)</p>
+subjects:
+  - general
+disciplines:
+  - general
+standards:
+  - iso-19115
+type: tool
+layout: tool
+---


### PR DESCRIPTION
Hello, I'm here submitting a proposal to include the 'geometa' R package in the list of tools. geometa is an R package that offers an API to read/write ISO/OGC metadata (mainly ISO 19115/19139). The tool has not been presented directly into RDA, but it had been introduced in a session of the Fisheries Data Interoperability working group through the presentation of use cases in which geometa is used to create ISO/OGC compliant metadata. Since this package works closely with 2 other R packages that allow to publish metadata files, i've made mention of them, please let me know if it is fine with that.

I've only annotated the file with iso-19115, but geometa also manage related metadata standards that could be worth mentioning in the standards lists:
* ISO 19119 (service metadata, derivate from ISO 19115)
* ISO 19110 (feature catalogue, used for data structure description)
what do you think?

Looking forward to your feedback