### PR TITLE
Update information for UK Polar Data Centre

### DIFF
--- a/use_cases/bas-pdc-british-antarctic-survey-polar-data-centre.md
+++ b/use_cases/bas-pdc-british-antarctic-survey-polar-data-centre.md
@@ -1,11 +1,11 @@
 ---
-title: BAS PDC - British Antarctic Survey Polar Data Centre
-slug: bas-pdc-british-antarctic-survey-polar-data-centre
+title: UK Polar Data Centre
+slug: uk-pdc
 description: <p>An organisation coordinating the management of data collected by UK-funded
   scientists in the polar regions, using an application profile that is harmonious
   with both <a href="../standards/iso-19115.html">ISO
   19115</a> and <a href="../standards/dif-directory-interchange-format.html">DIF</a>.</p>
-website: http://www.antarctica.ac.uk/dms/
+website: https://data.bas.ac.uk/
 subjects:
 - life-sciences
 - physical-sciences-and-mathematics


### PR DESCRIPTION
Hi, I work for the UK Polar Data Centre and came across this page. There are couple of thing that are out of date that I've updated:

* our name has changed to the 'UK Polar Data Centre' (to ensure its internationally unambiguous)
* we are separate to the British Antarctic Survey, though we are hosted at BAS (both physically and online) and are closely aligned
* our data catalogue URL has changed to https://data.bas.ac.uk

If there are any questions please let me know.