### PR TITLE
Adding MARCXML and MODS

### DIFF
--- a/standards/marcxml.md
+++ b/standards/marcxml.md
@@ -39,4 +39,3 @@ All control fields, including the leader are treated as a data string. Fields ar
 layout: standard
 type: standard
 ---
-

--- a/standards/marcxml.md
+++ b/standards/marcxml.md
@@ -1,0 +1,42 @@
+---
+title: MAchine Readable Cataloging record XML 
+slug: marcxml
+subjects:
+ - arts-and-humanities
+ - general
+disciplines:
+- P120 - Librarianship
+- P121 - Library studies
+specification_url: http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd
+status: Maintained by The Network Development and MARC Standards Office at the Library of Congress 
+website: http://www.loc.gov/standards/marcxml//
+related_vocabularies:
+ - name: MODS
+    url: http://www.loc.gov/standards/mods/
+ - name: MADS
+    url: http://www.loc.gov/standards/mads/
+mappings:
+ - name: MODS
+    url: http://www.loc.gov/standards/marcxml//
+sponsors:
+ - name: Library of Congress
+    url: https://www.loc.gov/
+ - name: Network Development and MARC Standards Office
+    url: http://www.loc.gov/marc/ndmso.html
+contact: Network Development and MARC Standards Office
+Library of Congress
+LS/NDMSO (4402)
+Washington, DC 20540-4402
+contact_email: ndmso@loc.gov
+standard_update_date: 2009-05-21
+version: Version 1.2
+description: |
+ <p>From Website: The Library of Congress' Network Development and MARC Standards Office is developing a framework for working with MARC data in a XML environment. This framework is intended to be flexible and extensible to allow users to work with MARC data in ways specific to their needs. The framework will contain many components such as schemas, stylesheets, and software tools developed and maintained by the Library of Congress.</p>
+ 
+<p>The core of the MARC XML framework is a simple XML schema which contains MARC data. This base schema output can be used where full MARC records are needed or act as a "bus" to enable MARC data records to go through further transformations such as toDublin Core and/or processes such as validation. The MARC XML schema will not need to be edited to reflect minor changes to MARC21. The schema retains the semantics of MARC.
+All control fields, including the leader are treated as a data string. Fields are treated as elements with the tag as an attribute and indicators treated as attributes. Subfields are treated as subelements with the subfield code as an attribute.</p>
+# The following are constants: do not modify
+layout: standard
+type: standard
+---
+

--- a/standards/marcxml.md
+++ b/standards/marcxml.md
@@ -29,9 +29,16 @@ contact_enail: ndmso@loc.gov
 standard_update_date: 2009-05-21
 version: Version 1.2
 description: |
-<p>From Website: The Library of Congress' Network Development and MARC Standards Office is developing a framework for working with MARC data in a XML environment. This framework is intended to be flexible and extensible to allow users to work with MARC data in ways specific to their needs. The framework will contain many components such as schemas, stylesheets, and software tools developed and maintained by the Library of Congress.</p>
-<p>The core of the MARC XML framework is a simple XML schema which contains MARC data. This base schema output can be used where full MARC records are needed or act as a "bus" to enable MARC data records to go through further transformations such as toDublin Core and/or processes such as validation. The MARC XML schema will not need to be edited to reflect minor changes to MARC21. The schema retains the semantics of MARC.
-All control fields, including the leader are treated as a data string. Fields are treated as elements with the tag as an attribute and indicators treated as attributes. Subfields are treated as subelements with the subfield code as an attribute.</p>
+  <p>From Website: The Library of Congress' Network Development and MARC Standards Office is developing a framework
+  for working with MARC data in a XML environment. This framework is intended to be flexible and extensible to allow
+  users to work with MARC data in ways specific to their needs. The framework will contain many components such as
+  schemas, stylesheets, and software tools developed and maintained by the Library of Congress.</p>
+  <p>The core of the MARC XML framework is a simple XML schema which contains MARC data. This base schema output can
+  be used where full MARC records are needed or act as a "bus" to enable MARC data records to go through further
+  transformations such as toDublin Core and/or processes such as validation. The MARC XML schema will not need to be
+  edited to reflect minor changes to MARC21. The schema retains the semantics of MARC. All control fields, including
+  the leader are treated as a data string. Fields are treated as elements with the tag as an attribute and indicators
+  treated as attributes. Subfields are treated as subelements with the subfield code as an attribute.</p>
 # The following are constants: do not modify
 layout: standard
 type: standard

--- a/standards/marcxml.md
+++ b/standards/marcxml.md
@@ -1,34 +1,35 @@
 ---
-title: MAchine Readable Cataloging record XML 
+title: MAchine Readable Cataloging record XML
 slug: marcxml
 subjects:
   - arts-and-humanities
   - general
 disciplines:
-  - P120 - Librarianship
-  - P121 - Library studies
+  # From https://www.hesa.ac.uk/support/documentation/jacs/jacs3-principal:
+  - (P120) Librarianship
+  - (P121) Library studies
 specification_url: http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd
-status: Maintained by The Network Development and MARC Standards Office at the Library of Congress 
-website: http://www.loc.gov/standards/marcxml//
+status: Maintained by The Network Development and MARC Standards Office at the Library of Congress
+website: http://www.loc.gov/standards/marcxml/
 related_vocabularies:
   - name: MODS
     url: http://www.loc.gov/standards/mods/
   - name: MADS
-    url: http://www.loc.gov/standards/mads/
-mappings:
+    url: http://www.loc.gov/standards/mads.
+mapings:
   - name: MODS
-    url: http://www.loc.gov/standards/marcxml//
+    url: http://www.loc.gov/standards/marcxml/
 sponsors:
   - name: Library of Congress
     url: https://www.loc.gov/
   - name: Network Development and MARC Standards Office
     url: http://www.loc.gov/marc/ndmso.html
 contact: Network Development and MARC Standards Office, Library of Congress, LS/NDMSO (4402), Washington, DC 20540-4402
-contact_email: ndmso@loc.gov
+contact_enail: ndmso@loc.gov
 standard_update_date: 2009-05-21
 version: Version 1.2
 description: |
-<p>From Website: The Library of Congress' Network Development and MARC Standards Office is developing a framework for working with MARC data in a XML environment. This framework is intended to be flexible and extensible to allow users to work with MARC data in ways specific to their needs. The framework will contain many components such as schemas, stylesheets, and software tools developed and maintained by the Library of Congress.</p> 
+<p>From Website: The Library of Congress' Network Development and MARC Standards Office is developing a framework for working with MARC data in a XML environment. This framework is intended to be flexible and extensible to allow users to work with MARC data in ways specific to their needs. The framework will contain many components such as schemas, stylesheets, and software tools developed and maintained by the Library of Congress.</p>
 <p>The core of the MARC XML framework is a simple XML schema which contains MARC data. This base schema output can be used where full MARC records are needed or act as a "bus" to enable MARC data records to go through further transformations such as toDublin Core and/or processes such as validation. The MARC XML schema will not need to be edited to reflect minor changes to MARC21. The schema retains the semantics of MARC.
 All control fields, including the leader are treated as a data string. Fields are treated as elements with the tag as an attribute and indicators treated as attributes. Subfields are treated as subelements with the subfield code as an attribute.</p>
 # The following are constants: do not modify

--- a/standards/marcxml.md
+++ b/standards/marcxml.md
@@ -2,37 +2,33 @@
 title: MAchine Readable Cataloging record XML 
 slug: marcxml
 subjects:
- - arts-and-humanities
- - general
+  - arts-and-humanities
+  - general
 disciplines:
-- P120 - Librarianship
-- P121 - Library studies
+  - P120 - Librarianship
+  - P121 - Library studies
 specification_url: http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd
 status: Maintained by The Network Development and MARC Standards Office at the Library of Congress 
 website: http://www.loc.gov/standards/marcxml//
 related_vocabularies:
- - name: MODS
+  - name: MODS
     url: http://www.loc.gov/standards/mods/
- - name: MADS
+  - name: MADS
     url: http://www.loc.gov/standards/mads/
 mappings:
- - name: MODS
+  - name: MODS
     url: http://www.loc.gov/standards/marcxml//
 sponsors:
- - name: Library of Congress
+  - name: Library of Congress
     url: https://www.loc.gov/
- - name: Network Development and MARC Standards Office
+  - name: Network Development and MARC Standards Office
     url: http://www.loc.gov/marc/ndmso.html
-contact: Network Development and MARC Standards Office
-Library of Congress
-LS/NDMSO (4402)
-Washington, DC 20540-4402
+contact: Network Development and MARC Standards Office, Library of Congress, LS/NDMSO (4402), Washington, DC 20540-4402
 contact_email: ndmso@loc.gov
 standard_update_date: 2009-05-21
 version: Version 1.2
 description: |
- <p>From Website: The Library of Congress' Network Development and MARC Standards Office is developing a framework for working with MARC data in a XML environment. This framework is intended to be flexible and extensible to allow users to work with MARC data in ways specific to their needs. The framework will contain many components such as schemas, stylesheets, and software tools developed and maintained by the Library of Congress.</p>
- 
+<p>From Website: The Library of Congress' Network Development and MARC Standards Office is developing a framework for working with MARC data in a XML environment. This framework is intended to be flexible and extensible to allow users to work with MARC data in ways specific to their needs. The framework will contain many components such as schemas, stylesheets, and software tools developed and maintained by the Library of Congress.</p> 
 <p>The core of the MARC XML framework is a simple XML schema which contains MARC data. This base schema output can be used where full MARC records are needed or act as a "bus" to enable MARC data records to go through further transformations such as toDublin Core and/or processes such as validation. The MARC XML schema will not need to be edited to reflect minor changes to MARC21. The schema retains the semantics of MARC.
 All control fields, including the leader are treated as a data string. Fields are treated as elements with the tag as an attribute and indicators treated as attributes. Subfields are treated as subelements with the subfield code as an attribute.</p>
 # The following are constants: do not modify

--- a/standards/mods.md
+++ b/standards/mods.md
@@ -1,0 +1,40 @@
+---
+title: Metadata Object Description Schema (MODS)
+slug: mods
+subjects:
+  - arts-and-humanities
+  - general
+disciplines:
+  - P120 - Librarianship
+  - P121 - Library studies
+specification_url: http://www.loc.gov/standards/mods/mods-schemas.html
+status: maintained by the Network Development and MARC Standards Office of the Library of Congress with input from users.
+website: http://www.loc.gov/standards/mods/
+related_vocabularies:
+  - name: MADS
+    url: http://www.loc.gov/standards/mads/
+  - name: MARCXML
+    Url: http://www.loc.gov/standards/marcxml/
+mappings:
+  - name: Marc 21 to MODS 3.7
+    url: http://www.loc.gov/standards/mods/v3/mods-mapping-3-7.html
+  - name: DC to MODS (versions 3.2-3.5)
+    url: http://www.loc.gov/standards/mods/dcsimple-mods.html
+sponsors:
+  - name: Library of Congress
+    url: https://www.loc.gov/
+  - name: Network Development and MARC Standards Office
+    url: http://www.loc.gov/marc/ndmso.html
+contact: Network Development and MARC Standards Office, Library of Congress, LS/NDMSO (4402), Washington, DC 20540-4402
+contact_email: ndmso@loc.gov
+standard_update_date: 2018-01-04
+version: 3.7
+description: |
+  <p>A few sentences describing the standard and for what it is meant to be
+  used. Use HTML tags to format the text if needed. You can optionally
+  include who developed and maintains the standard, and when it was last
+  revised, if the above fields need to be clarified.</p>
+# The following are constants: do not modify
+layout: standard
+type: standard
+---


### PR DESCRIPTION
MARCXML and MODS are widely-used metadata standards originally from the library field.